### PR TITLE
adding instructions to helm-dependency example about subchart conditions

### DIFF
--- a/helm-dependency/README.md
+++ b/helm-dependency/README.md
@@ -24,3 +24,32 @@ wordpress:
     rootUser:
       password: baz
 ```
+
+### Subchart Note
+
+The wordpress chart referenced in this example contains a subchart for mariadb as specified in the requirements.yaml file of the wordpress chart:
+```yaml
+- name: mariadb
+  version: 5.x.x
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: mariadb.enabled
+  tags:
+    - wordpress-database
+```
+
+In order to disable this chart, you must set the value to false for both `mariadb.enabled` and `wordpress.mariadb.enabled`. The first is used by the mariadb subchart condition field, the second is used by the wordpress chart deployment template. An example demonstration is available in the values-nomaria.yaml file:
+```yaml
+mariadb:
+  enabled: false
+
+wordpress:
+  wordpressPassword: foo
+  mariadb:
+    enabled: false
+  externalDatabase:
+    host: localhost
+    user: bn_wordpress
+    password: ""
+    database: bitnami_wordpress
+    port: 3306
+```

--- a/helm-dependency/values-nomaria.yaml
+++ b/helm-dependency/values-nomaria.yaml
@@ -1,0 +1,13 @@
+mariadb:
+  enabled: false
+
+wordpress:
+  wordpressPassword: foo
+  mariadb:
+    enabled: false
+  externalDatabase:
+    host: localhost
+    user: bn_wordpress
+    password: ""
+    database: bitnami_wordpress
+    port: 3306


### PR DESCRIPTION
wanted to touch up the helm dependency example to clear up some confusing behavior around subchart conditions.

basically, converting a chart to run on argo-cd probably involves some duplication of the various subchart condition values to the top level namespace, but leaving them in the chart namespace as well in case they are referenced there. I've included an example based around the wordpress chart that's already in place, and I've added a short section to the readme.

happy to make changes or hear any sugestions you may have! 