### PR TITLE
Use apps/v1 API for Deployment resources

### DIFF
--- a/guestbook/guestbook-ui-deployment.yaml
+++ b/guestbook/guestbook-ui-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: guestbook-ui

--- a/helm-guestbook/templates/deployment.yaml
+++ b/helm-guestbook/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "helm-guestbook.fullname" . }}

--- a/jsonnet-guestbook-tla/guestbook-ui.jsonnet
+++ b/jsonnet-guestbook-tla/guestbook-ui.jsonnet
@@ -27,7 +27,7 @@ function (
         }
     },
     {
-        "apiVersion": "apps/v1beta2",
+        "apiVersion": "apps/v1",
         "kind": "Deployment",
         "metadata": {
             "name": name

--- a/jsonnet-guestbook/guestbook-ui.jsonnet
+++ b/jsonnet-guestbook/guestbook-ui.jsonnet
@@ -21,7 +21,7 @@ local params = import 'params.libsonnet';
       }
    },
    {
-      "apiVersion": "apps/v1beta2",
+      "apiVersion": "apps/v1",
       "kind": "Deployment",
       "metadata": {
          "name": params.name

--- a/ksonnet-guestbook/components/guestbook-ui.jsonnet
+++ b/ksonnet-guestbook/components/guestbook-ui.jsonnet
@@ -21,7 +21,7 @@ local params = std.extVar("__ksonnet/params").components["guestbook-ui"];
       }
    },
    {
-      "apiVersion": "apps/v1beta2",
+      "apiVersion": "apps/v1",
       "kind": "Deployment",
       "metadata": {
          "name": params.name

--- a/kustomize-guestbook/guestbook-ui-deployment.yaml
+++ b/kustomize-guestbook/guestbook-ui-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: guestbook-ui

--- a/plugins/kustomized-helm/overlays/guestbook-deployment.yaml
+++ b/plugins/kustomized-helm/overlays/guestbook-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: release-name-helm-guestbook


### PR DESCRIPTION
Related to https://github.com/argoproj/argo-cd/issues/2371 - this PR replaces the API version from `apps/v1beta2` to `apps/v1` for all resources of kind `Deployment` in the example applications, so they can be deployed to Kubernetes v1.16