### PR TITLE
Deployment name not found when install hem-dependency example.

### DIFF
--- a/helm-dependency/README.md
+++ b/helm-dependency/README.md
@@ -17,6 +17,7 @@ A custom values.yaml is used to customize the parameters of the wordpress helm c
 
 ```yaml
 wordpress:
+  fullname: myWordPress
   wordpressPassword: foo
   mariadb:
     db:
@@ -43,6 +44,7 @@ mariadb:
   enabled: false
 
 wordpress:
+  fullname: myWordPress
   wordpressPassword: foo
   mariadb:
     enabled: false

--- a/helm-dependency/values-nomaria.yaml
+++ b/helm-dependency/values-nomaria.yaml
@@ -2,6 +2,7 @@ mariadb:
   enabled: false
 
 wordpress:
+  fullname: myWordPress
   wordpressPassword: foo
   mariadb:
     enabled: false

--- a/helm-dependency/values.yaml
+++ b/helm-dependency/values.yaml
@@ -1,4 +1,5 @@
 wordpress:
+  fullname: myWordPress
   wordpressPassword: foo
   mariadb:
     db:


### PR DESCRIPTION
For https://github.com/argoproj/argocd-example-apps/issues/49