### PR TITLE
docs: Add helm3-dependency example demonstrating customization of OTS chart using Helm 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ to explore ArgoCD and GitOps!
 | [pre-post-sync](pre-post-sync/) | Demonstrates Argo CD PreSync and PostSync hooks |
 | [sync-waves](sync-waves/) | Demonstrates Argo CD sync waves with hooks |
 | [helm-dependency](helm-dependency/) | Demonstrates how to customize an OTS (off-the-shelf) helm chart from an upstream repo |
+| [helm3-dependency](helm3-dependency/) | Demonstrates how to customize an OTS (off-the-shelf) helm chart from an upstream repo usgin Helm 3 |
 | [sock-shop](sock-shop/) | A microservices demo app (https://microservices-demo.github.io) |
 | [plugins](plugins/) | Apps which demonstrate config management plugins usage |
 | [blue-green](blue-green/) | Demonstrates how to implement blue-green deployment using [Argo Rollouts](https://github.com/argoproj/argo-rollouts)

--- a/helm3-dependency/Chart.yaml
+++ b/helm3-dependency/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: wordpress
+description: Wordpress Argo demo
+type: application
+version: 0.1.0
+appVersion: 5.0.2
+
+dependencies:
+- name: wordpress
+  version: 5.0.2
+  repository: https://kubernetes-charts.storage.googleapis.com

--- a/helm3-dependency/README.md
+++ b/helm3-dependency/README.md
@@ -1,0 +1,55 @@
+# Helm 3 Dependencies
+
+This example application demonstrates how an OTS (off-the-shelf) helm chart can be retrieved and
+pinned to a specific helm sem version from an upstream helm repository, and customized using a custom
+values.yaml in the private git repository.
+
+In this example, the wordpress application is pulled from the stable helm repo, and pinned to v5.0.2:
+
+```yaml
+dependencies:
+- name: wordpress
+  version: 5.0.2
+  repository: https://kubernetes-charts.storage.googleapis.com
+```
+
+A custom values.yaml is used to customize the parameters of the wordpress helm chart:
+
+```yaml
+wordpress:
+  wordpressPassword: foo
+  mariadb:
+    db:
+      password: bar
+    rootUser:
+      password: baz
+```
+
+### Subchart Note
+
+The wordpress chart referenced in this example contains a subchart for mariadb as specified in the requirements.yaml file of the wordpress chart:
+```yaml
+- name: mariadb
+  version: 5.x.x
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: mariadb.enabled
+  tags:
+    - wordpress-database
+```
+
+In order to disable this chart, you must set the value to false for both `mariadb.enabled` and `wordpress.mariadb.enabled`. The first is used by the mariadb subchart condition field, the second is used by the wordpress chart deployment template. An example demonstration is available in the values-nomaria.yaml file:
+```yaml
+mariadb:
+  enabled: false
+
+wordpress:
+  wordpressPassword: foo
+  mariadb:
+    enabled: false
+  externalDatabase:
+    host: localhost
+    user: bn_wordpress
+    password: ""
+    database: bitnami_wordpress
+    port: 3306
+```

--- a/helm3-dependency/values-nomaria.yaml
+++ b/helm3-dependency/values-nomaria.yaml
@@ -1,0 +1,13 @@
+mariadb:
+  enabled: false
+
+wordpress:
+  wordpressPassword: foo
+  mariadb:
+    enabled: false
+  externalDatabase:
+    host: localhost
+    user: bn_wordpress
+    password: ""
+    database: bitnami_wordpress
+    port: 3306

--- a/helm3-dependency/values.yaml
+++ b/helm3-dependency/values.yaml
@@ -1,0 +1,7 @@
+wordpress:
+  wordpressPassword: foo
+  mariadb:
+    db:
+      password: bar
+    rootUser:
+      password: baz


### PR DESCRIPTION
I tried to use OTS chart in Argo following the helm-dependency example and spent some time to find out why Argo uses helm2 for my chart instead of v3 (my subchart was made for helm 3). And finally it turned out you must provide a helm 3 compatible Chart.yaml in the root directory instead of only "name" (like in example) and write dependencies there instead of requirements.yaml file.