### PR TITLE
Updating plugins/kustomized-helm example

### DIFF
--- a/plugins/kustomized-helm/README.md
+++ b/plugins/kustomized-helm/README.md
@@ -14,9 +14,13 @@ Use following steps to try the application:
         command: ["/bin/sh", "-c"]
         args: ["helm dependency build"]
       generate:
-        command: [sh, -c]
-        args: ["helm template --release-name release-name . > all.yaml && kustomize build"]
+        command: ["/bin/sh", "-c"]
+        args: ["helm template . --name-template $ARGOCD_APP_NAME --namespace $ARGOCD_APP_NAMESPACE --kube-version $KUBE_VERSION > all.yaml && kustomize build"]
 ```
+
+Notes:
+- `$ARGOCD_APP_NAME`, `$ARGOCD_APP_NAMESPACE` and `$KUBE_VERSION` are environment variables that exists in the context of the plugin.
+- setting `--kube-version` is important as helm template can mock up data which may not match the actual cluster version.
 
 * create application using `kustomized-helm` as a config management plugin name:
 


### PR DESCRIPTION
Updating the `helm template` command with a more complete example.

This command more resembles the helm command that is executed by the built-in helm tooling.

- `--name-template`
- `--namespace`
- `--kube-version`

are all parameters that the built-in helm template command has.
