### PR TITLE
feat: add the guestbook app as a raw KCL using KusionStack CMP.

### DIFF
--- a/plugins/kusionstack/README.md
+++ b/plugins/kusionstack/README.md
@@ -1,0 +1,30 @@
+# KusionStack
+
+[KusionStack](https://kusionstack.io/) is a highly flexible programmable technology stack to enable unified application delivery and operation, which aims to help enterprises build an application-centric configuration management plane and DevOps ecosystem.
+
+Use the following steps to try the application:
+
+* Follow instructions from the [guide](https://kusionstack.io/docs/user_docs/guides/argocd/drift-detection-by-argocd) to make sure `kusion` binary is available in `argocd-repo-server` pod.
+* Register `kusion` plugin `argocd-cm` ConfigMap:
+
+```yaml
+apiVersion: v1
+data:
+  configManagementPlugins: |
+    - name: kusion
+      generate:
+        command: ["sh", "-c"]
+        args: ["kusion compile"]
+      lockRepo: true
+```
+
+* Create a guestbook application using `kusion` as a config management plugin name.
+
+```
+argocd app create guestbook-test \
+    --repo https://github.com/KusionStack/konfig.git \
+    --path appops/guestbook-frontend/prod \
+    --dest-namespace default \
+    --dest-server https://kubernetes.default.svc \
+    --config-management-plugin kusion
+```


### PR DESCRIPTION
## Feature

[KusionStack](https://kusionstack.io/) is a highly flexible programmable technology stack to enable unified application delivery and operation, which aims to help enterprises build an application-centric configuration management plane and DevOps ecosystem.

This PR aims to add the guestbook app as a raw KCL. KCL is a new open-source constraint-based record & functional language mainly used in configuration and policy scenarios. We are actively exploring the combination of KCL and argocd in writing cloud-native configurations. 

Code Location: https://github.com/KusionStack/konfig/blob/main/appops/guestbook-frontend/test/main.k

More information: https://kusionstack.io/docs/user_docs/guides/argocd/drift-detection-by-argocd/.

@alexec, @jessesuen. I would like to invite you to take a look as reviewers. Thank you for all!