### PR TITLE
Nginx: Add example

### DIFF
--- a/nginx/deployment.yaml
+++ b/nginx/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-nginx
+spec:
+  selector:
+    matchLabels:
+      run: my-nginx
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: my-nginx
+    spec:
+      containers:
+      - image: nginx
+        name: my-nginx
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "250m"
+          limits:
+            memory: "384Mi"
+            cpu: "500m"
+        ports:
+        - containerPort: 443
+        - containerPort: 80

--- a/nginx/deployment.yaml
+++ b/nginx/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: my-nginx
+  namespace: nginx
 spec:
   selector:
     matchLabels:
@@ -20,8 +21,7 @@ spec:
             memory: "128Mi"
             cpu: "250m"
           limits:
-            memory: "384Mi"
-            cpu: "500m"
+            memory: "128Mi"
         ports:
         - containerPort: 443
         - containerPort: 80

--- a/nginx/service.yaml
+++ b/nginx/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-nginx
+  labels:
+    run: my-nginx
+spec:
+  type: NodePort
+  ports:
+  - port: 8081
+    targetPort: 80
+    nodePort: 31704
+    protocol: TCP
+    name: http
+  - port: 443
+    nodePort: 32453
+    protocol: TCP
+    name: https
+  selector:
+    run: my-nginx

--- a/nginx/service.yaml
+++ b/nginx/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: my-nginx
+  namespace: nginx
   labels:
     run: my-nginx
 spec:


### PR DESCRIPTION
The current `guestbook` example does not run correctly on `aarch64`.
This PR contributes a deployment of `nginx` which can run on both `x64` and `aarch64`.