### PR TITLE
Add Degraded Example Resources

### DIFF
--- a/degraded-example/Readme.md
+++ b/degraded-example/Readme.md
@@ -1,0 +1,14 @@
+# Degraded Example
+
+This folder contains Kubernetes manifests for a degraded application. The purpose of this app is to demonstrate how ArgoCD displays and manages degraded resources.
+
+## Purpose
+The `degraded-example` app is designed to help users understand how ArgoCD handles and displays issues such as:
+- Image pull errors
+- Misconfigured services
+- Missing dependencies (e.g., ConfigMaps, Secrets)
+- Storage and scheduling issues
+
+These examples simulate real-world problems that can occur in Kubernetes deployments.
+
+---

--- a/degraded-example/examples/conflicting-rules.yml
+++ b/degraded-example/examples/conflicting-rules.yml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: conflicting-rules-ingress
+spec:
+  rules:
+  - host: example.com
+    http:
+      paths:
+      - path: /path
+        pathType: Prefix
+        backend:
+          service:
+            name: service-a
+            port:
+              number: 80
+      - path: /path # Duplicate path causing conflict
+        pathType: Prefix
+        backend:
+          service:
+            name: service-b
+            port:
+              number: 80

--- a/degraded-example/examples/headless-service.yml
+++ b/degraded-example/examples/headless-service.yml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: invalid-statefulset
+spec:
+  serviceName: missing-headless-service # Service does not exist
+  replicas: 1
+  selector:
+    matchLabels:
+      app: invalid-statefulset
+  template:
+    metadata:
+      labels:
+        app: invalid-statefulset
+    spec:
+      containers:
+      - name: main-container
+        image: nginx:latest

--- a/degraded-example/examples/insufficient-resources.yml
+++ b/degraded-example/examples/insufficient-resources.yml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: insufficient-resources
+  labels:
+    app: insufficient-resources
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: insufficient-resources
+  template:
+    metadata:
+      labels:
+        app: insufficient-resources
+    spec:
+      containers:
+      - name: main-container
+        image: nginx:latest
+        resources:
+          requests:
+            memory: "10Ti" # Exceeds cluster capacity
+            cpu: "5000"    # Exceeds cluster capacity

--- a/degraded-example/examples/insufficient-volume-claims.yml
+++ b/degraded-example/examples/insufficient-volume-claims.yml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: insufficient-pvc-statefulset
+spec:
+  serviceName: some-service
+  replicas: 3
+  selector:
+    matchLabels:
+      app: insufficient-pvc-statefulset
+  template:
+    metadata:
+      labels:
+        app: insufficient-pvc-statefulset
+    spec:
+      containers:
+      - name: main-container
+        image: nginx:latest
+        volumeMounts:
+        - name: data
+          mountPath: /data
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 1Gi
+      storageClassName: non-existent-storage-class # Causes PVC failure

--- a/degraded-example/examples/invalid-backend.yml
+++ b/degraded-example/examples/invalid-backend.yml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: invalid-ingress
+spec:
+  rules:
+  - host: example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: non-existent-service # Service does not exist
+            port:
+              number: 80

--- a/degraded-example/examples/invalid-key.yml
+++ b/degraded-example/examples/invalid-key.yml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: invalid-configmap
+data:
+  invalid-key$: "This key is invalid" # Invalid key name

--- a/degraded-example/examples/invalid-metrics.yml
+++ b/degraded-example/examples/invalid-metrics.yml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: invalid-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: some-deployment
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: invalid-metric # Invalid resource metric
+      target:
+        type: Utilization
+        averageUtilization: 50

--- a/degraded-example/examples/invalid-nodeselector.yml
+++ b/degraded-example/examples/invalid-nodeselector.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: degraded-pod
+spec:
+  nodeSelector:
+    invalid-key: invalid-value # Node selector does not match any node
+  containers:
+  - name: main-container
+    image: nginx:latest

--- a/degraded-example/examples/invalid-portconfiguration.yml
+++ b/degraded-example/examples/invalid-portconfiguration.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: invalid-port-service
+spec:
+  selector:
+    app: some-app
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 9999 # No container listens on this port

--- a/degraded-example/examples/invalid-rules.yml
+++ b/degraded-example/examples/invalid-rules.yml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: invalid-networkpolicy
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          non-existent-label: value # No matching namespace

--- a/degraded-example/examples/invalid-schedule.yml
+++ b/degraded-example/examples/invalid-schedule.yml
@@ -1,0 +1,14 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: invalid-cronjob
+spec:
+  schedule: "invalid-schedule" # Invalid cron expression
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: main-container
+            image: nginx:latest
+          restartPolicy: OnFailure

--- a/degraded-example/examples/invalid-schema.yml
+++ b/degraded-example/examples/invalid-schema.yml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: invalid-crd.example.com
+spec:
+  group: example.com
+  names:
+    kind: InvalidCRD
+    plural: invalidcrds
+    singular: invalidcrd
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: string # Invalid schema (should be an object)

--- a/degraded-example/examples/invalid-selector.yml
+++ b/degraded-example/examples/invalid-selector.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: degraded-app-service
+spec:
+  selector:
+    app: non-existent-selector # Selector mismatch to cause Service issues
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080

--- a/degraded-example/examples/invalid-volumemount.yml
+++ b/degraded-example/examples/invalid-volumemount.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: invalid-volume-pod
+spec:
+  containers:
+  - name: main-container
+    image: nginx:latest
+    volumeMounts:
+    - mountPath: /data
+      name: missing-volume # Volume not defined

--- a/degraded-example/examples/missing-configmap.yml
+++ b/degraded-example/examples/missing-configmap.yml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: degraded-app-config
+  labels:
+    app: degraded-app-config
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: degraded-app-config
+  template:
+    metadata:
+      labels:
+        app: degraded-app-config
+    spec:
+      containers:
+      - name: main-container
+        image: nginx:latest
+        envFrom:
+        - configMapRef:
+            name: missing-configmap # ConfigMap not created

--- a/degraded-example/examples/missing-image.yml
+++ b/degraded-example/examples/missing-image.yml
@@ -1,0 +1,11 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: missing-image-job
+spec:
+  template:
+    spec:
+      containers:
+      - name: main-container
+        image: missing-image:latest # Non-existent image
+      restartPolicy: Never

--- a/degraded-example/examples/missing-secret.yml
+++ b/degraded-example/examples/missing-secret.yml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: invalid-serviceaccount
+secrets:
+- name: missing-secret # Secret not created

--- a/degraded-example/examples/non-existing-image.yml
+++ b/degraded-example/examples/non-existing-image.yml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: degraded-app
+  labels:
+    app: degraded-app
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: degraded-app
+  template:
+    metadata:
+      labels:
+        app: degraded-app
+    spec:
+      containers:
+      - name: main-container
+        image: non-existent-image:latest # Non-existent image to cause ImagePullBackOff
+        ports:
+        - containerPort: 8080

--- a/degraded-example/examples/unavailable-storageclass.yml
+++ b/degraded-example/examples/unavailable-storageclass.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: degraded-pvc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: non-existent-storage-class # Invalid storage class

--- a/degraded-example/examples/zero-replicas.yml
+++ b/degraded-example/examples/zero-replicas.yml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: zero-replicas-replicaset
+spec:
+  replicas: 0 # No pods will be created
+  selector:
+    matchLabels:
+      app: zero-replicas-replicaset
+  template:
+    metadata:
+      labels:
+        app: zero-replicas-replicaset
+    spec:
+      containers:
+      - name: main-container
+        image: nginx:latest


### PR DESCRIPTION
#289 

### **Description :**

- This pull request introduces a new degraded-example folder containing Kubernetes manifests that simulate various degraded or broken resource scenarios. 

**Changes Made:**
1) New Folder:
2) Added Example Manifests:
3) Added README.md file

**Purpose :**
- Help users understand how ArgoCD displays and handles degraded applications.
- Provide realistic failure scenarios for training and testing purposes.
- Enhance the repository's utility for demonstrations and workshops.

**Checklist:**
- [x] Added detailed examples of degraded resources.
- [x]  Updated README with instructions and descriptions.
- [x] Verified manifests for correctness.
- [x] Tested examples in a Kubernetes cluster.
