### PR TITLE
fix: Replace heptio-images with argocd-e2e-container

### DIFF
--- a/blue-green/values.yaml
+++ b/blue-green/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: gcr.io/heptio-images/ks-guestbook-demo
+  repository: quay.io/argoprojlabs/argocd-e2e-container
   tag: 0.1
   pullPolicy: IfNotPresent
 

--- a/guestbook/guestbook-ui-deployment.yaml
+++ b/guestbook/guestbook-ui-deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app: guestbook-ui
     spec:
       containers:
-      - image: gcr.io/heptio-images/ks-guestbook-demo:0.2
+      - image: quay.io/argoprojlabs/argocd-e2e-container:0.2
         name: guestbook-ui
         ports:
         - containerPort: 80

--- a/helm-guestbook/values.yaml
+++ b/helm-guestbook/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: gcr.io/heptio-images/ks-guestbook-demo
+  repository: quay.io/argoprojlabs/argocd-e2e-container
   tag: 0.1
   pullPolicy: IfNotPresent
 

--- a/jsonnet-guestbook-tla/guestbook-ui.jsonnet
+++ b/jsonnet-guestbook-tla/guestbook-ui.jsonnet
@@ -1,6 +1,6 @@
 function (
     containerPort=80, 
-    image="gcr.io/heptio-images/ks-guestbook-demo:0.2", 
+    image="quay.io/argoprojlabs/argocd-e2e-container:0.2", 
     name="jsonnet-guestbook-ui",
     replicas=1,
     servicePort=80, 

--- a/jsonnet-guestbook/params.libsonnet
+++ b/jsonnet-guestbook/params.libsonnet
@@ -1,6 +1,6 @@
 {
   containerPort: 80,
-  image: "gcr.io/heptio-images/ks-guestbook-demo:0.2",
+  image: "quay.io/argoprojlabs/argocd-e2e-container:0.2",
   name: "jsonnet-guestbook-ui",
   replicas: 1,
   servicePort: 80,

--- a/kustomize-guestbook/guestbook-ui-deployment.yaml
+++ b/kustomize-guestbook/guestbook-ui-deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app: guestbook-ui
     spec:
       containers:
-      - image: gcr.io/heptio-images/ks-guestbook-demo:0.1
+      - image: quay.io/argoprojlabs/argocd-e2e-container:0.1
         name: guestbook-ui
         ports:
         - containerPort: 80

--- a/plugins/kustomized-helm/overlays/guestbook-deployment.yaml
+++ b/plugins/kustomized-helm/overlays/guestbook-deployment.yaml
@@ -7,4 +7,4 @@ spec:
     spec:
       containers:
         - name: helm-guestbook
-          image: "gcr.io/heptio-images/ks-guestbook-demo:0.2"
+          image: "quay.io/argoprojlabs/argocd-e2e-container:0.2"


### PR DESCRIPTION
Related to
- https://github.com/argoproj/argo-cd/pull/22975

And discussion in **#argo-cd-contributors** Slack:
> <img width="719" alt="Image" src="https://github.com/user-attachments/assets/a1a6d905-a559-4c26-abdd-e06f673adee2" />
> 
> https://cloud-native.slack.com/archives/C020XM04CUW/p1747231505846999

FYI @crenshaw-dev @agaudreault 

Another approach to keep real "guestbook" app, rebuild it and push it to quay.io. Source is from kubernetes/examples:
https://github.com/kubernetes/examples/blob/master/guestbook/php-redis/Dockerfile