### PR TITLE
chore(k8s): modernize ingress annotations and nodeSelector label

### DIFF
--- a/sock-shop/base/carts-db-dep.yaml
+++ b/sock-shop/base/carts-db-dep.yaml
@@ -38,4 +38,4 @@ spec:
           emptyDir:
             medium: Memory
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/sock-shop/base/carts-dep.yaml
+++ b/sock-shop/base/carts-dep.yaml
@@ -61,4 +61,4 @@ spec:
           emptyDir:
             medium: Memory
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/sock-shop/base/catalogue-db-dep.yaml
+++ b/sock-shop/base/catalogue-db-dep.yaml
@@ -27,4 +27,4 @@ spec:
         - name: mysql
           containerPort: 3306
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/sock-shop/base/catalogue-dep.yaml
+++ b/sock-shop/base/catalogue-dep.yaml
@@ -49,4 +49,4 @@ spec:
           initialDelaySeconds: 180
           periodSeconds: 3
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/sock-shop/base/front-end-dep.yaml
+++ b/sock-shop/base/front-end-dep.yaml
@@ -48,4 +48,4 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 3
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/sock-shop/base/front-end-ingress.yaml
+++ b/sock-shop/base/front-end-ingress.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     name: front-end
   annotations:
-    ingress.kubernetes.io/proxy-body-size: 100M
-    ingress.kubernetes.io/app-root: '/'
+    nginx.ingress.kubernetes.io/proxy-body-size: 100M
+    nginx.ingress.kubernetes.io/app-root: '/'
 spec:
   ingressClassName: nginx
   rules:

--- a/sock-shop/base/orders-db-dep.yaml
+++ b/sock-shop/base/orders-db-dep.yaml
@@ -38,4 +38,4 @@ spec:
           emptyDir:
             medium: Memory
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/sock-shop/base/orders-dep.yaml
+++ b/sock-shop/base/orders-dep.yaml
@@ -61,4 +61,4 @@ spec:
           emptyDir:
             medium: Memory
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/sock-shop/base/payment-dep.yaml
+++ b/sock-shop/base/payment-dep.yaml
@@ -49,4 +49,4 @@ spec:
           initialDelaySeconds: 180
           periodSeconds: 3
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/sock-shop/base/queue-master-dep.yaml
+++ b/sock-shop/base/queue-master-dep.yaml
@@ -45,4 +45,4 @@ spec:
           initialDelaySeconds: 180
           periodSeconds: 3
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/sock-shop/base/rabbitmq-dep.yaml
+++ b/sock-shop/base/rabbitmq-dep.yaml
@@ -41,4 +41,4 @@ spec:
         - containerPort: 9090
           name: exporter
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/sock-shop/base/session-db-dep.yaml
+++ b/sock-shop/base/session-db-dep.yaml
@@ -33,4 +33,4 @@ spec:
               - SETUID
           readOnlyRootFilesystem: true
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/sock-shop/base/shipping-dep.yaml
+++ b/sock-shop/base/shipping-dep.yaml
@@ -61,4 +61,4 @@ spec:
           emptyDir:
             medium: Memory
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/sock-shop/base/user-db-dep.yaml
+++ b/sock-shop/base/user-db-dep.yaml
@@ -39,4 +39,4 @@ spec:
           emptyDir:
             medium: Memory
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/sock-shop/base/user-dep.yaml
+++ b/sock-shop/base/user-dep.yaml
@@ -52,4 +52,4 @@ spec:
           initialDelaySeconds: 180
           periodSeconds: 3
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux


### PR DESCRIPTION
## Summary
Update legacy NGINX Ingress annotations and deprecated nodeSelector label to current, recommended keys.

## What’s changed
- Ingress: replace **legacy** `ingress.kubernetes.io/*` with `nginx.ingress.kubernetes.io/`.
- Deployments: replace **deprecated** node label `beta.kubernetes.io/os` with `kubernetes.io/os`.

## Impact
No behavioral change expected.

## References
- [Kubernetes Well-Known Labels, Annotations and Taints](https://kubernetes.io/docs/reference/labels-annotations-taints/)
- [Ingress-NGINX Annotations](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/)