### PR TITLE
fix: add image multi platform

### DIFF
--- a/helm-guestbook/values.yaml
+++ b/helm-guestbook/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: gcr.io/google-samples/gb-frontend
+  repository: gersontpc/gb-frontend
   tag: v5
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
The image has been changed from single platform to multi-platform. In arm64 environments, the application crashes. The added image references the same gcr.io/google-samples/gb-frontend image; it was only modified to use buildx to create a new image to support both (amd64 and arm64) architectures.